### PR TITLE
Set {trigger: true} as default for history.navigate. Fixes #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ open: function(id) { ... }
 
 ### navigate `router.navigate(fragment, [options])`
 
-Whenever you reach a point in your application that you'd like to save as a URL, call *navigate* in order to update the URL. If you wish to also call the route function, set the `trigger` option to `true`. To update the URL without creating an entry in the browser's history, set the `replace` option to `true`.
+Whenever you reach a point in your application that you'd like to save as a URL, call *navigate* in order to update the URL. Route function will be called by default, but if you want to prevent it, you can set the `trigger` option to `false`. To update the URL without creating an entry in the browser's history, set the `replace` option to `true`.
 
 ```javascript
 openPage: function(pageNumber) {
@@ -135,11 +135,11 @@ openPage: function(pageNumber) {
 
 // Or ...
 
-app.navigate("help/troubleshooting", {trigger: true});
+app.navigate("help/troubleshooting", {trigger: false});
 
 // Or ...
 
-app.navigate("help/troubleshooting", {trigger: true, replace: true});
+app.navigate("help/troubleshooting", {replace: true});
 ```
 
 ### redirectTo `router.redirectTo(fragment)`

--- a/ampersand-history.js
+++ b/ampersand-history.js
@@ -146,12 +146,16 @@ _.extend(History.prototype, Events, {
         this.handlers.unshift({route: route, callback: callback});
     },
 
+    urlChanged: function (url) {
+        var current = this.getFragment();
+        if (current === this.fragment) return false;
+        return true;
+    },
+
     // Checks the current URL to see if it has changed, and if it has,
     // calls `loadUrl`.
     checkUrl: function (e) {
-        var current = this.getFragment();
-        if (current === this.fragment) return false;
-        this.loadUrl();
+        this.urlChanged && this.loadUrl();
     },
 
     // Attempt to load the current URL fragment. If a route succeeds with a
@@ -171,12 +175,12 @@ _.extend(History.prototype, Events, {
     // 'replace' option is passed. You are responsible for properly URL-encoding
     // the fragment in advance.
     //
-    // The options object can contain `trigger: true` if you wish to have the
-    // route callback be fired (not usually desirable), or `replace: true`, if
+    // The options object can contain `trigger: false` if you wish to have the
+    // route callback not be fired (sometimes desirable), or `replace: true`, if
     // you wish to modify the current URL without adding an entry to the history.
     navigate: function (fragment, options) {
         if (!History.started) return false;
-        if (!options || options === true) options = {trigger: !!options};
+        options = _.extend({trigger: true}, options);
 
         var url = this.root + (fragment = this.getFragment(fragment || ''));
 
@@ -202,7 +206,8 @@ _.extend(History.prototype, Events, {
         } else {
             return this.location.assign(url);
         }
-        if (options.trigger) return this.loadUrl(fragment);
+
+        if (options.trigger && this.urlChanged()) return this.loadUrl(fragment);
     },
 
     // Update the hash location, either replacing the current entry, or adding

--- a/ampersand-router.js
+++ b/ampersand-router.js
@@ -68,7 +68,7 @@ _.extend(Router.prototype, Events, {
     // Helper for doing `internal` redirects without adding to history
     // and thereby breaking backbutton functionality.
     redirectTo: function (newUrl) {
-        this.navigate(newUrl, {replace: true, trigger: true});
+        this.navigate(newUrl, {replace: true});
     },
 
     // Bind all defined routes to `history`. We have to reverse the

--- a/test/index.js
+++ b/test/index.js
@@ -247,13 +247,13 @@ function module(moduleName, opts) {
     });
 
     test("routes via navigate", 2, function (t) {
-        Backbone.history.navigate('search/manhattan/p20', {trigger: true});
+        Backbone.history.navigate('search/manhattan/p20');
         t.equal(router.query, 'manhattan');
         t.equal(router.page, '20');
     });
 
     test("routes via navigate with params", 1, function (t) {
-        Backbone.history.navigate('query/test?a=b', {trigger: true});
+        Backbone.history.navigate('query/test?a=b');
         t.equal(router.queryArgs, 'a=b');
     });
 
@@ -267,6 +267,7 @@ function module(moduleName, opts) {
         t.ok(Backbone.history.navigate('search/manhattan/p20', true));
     });
 
+    // I guess that this test is currently redundant after we switched to `{trigger: true}` by default
     test("route precedence via navigate", 6, function (t) {
         // check both 0.9.x and backwards-compatibility options
         _.each([ { trigger: true }, true ], function (options) {
@@ -290,7 +291,7 @@ function module(moduleName, opts) {
 
     test("use implicit callback if none provided", 1, function (t) {
         router.count = 0;
-        router.navigate('implicit', {trigger: true});
+        router.navigate('implicit');
         t.equal(router.count, 1);
     });
 
@@ -427,7 +428,7 @@ function module(moduleName, opts) {
 
     test("#967 - Route callback gets passed encoded values.", 3, function (t) {
         var route = 'has%2Fslash/complex-has%23hash/has%20space';
-        Backbone.history.navigate(route, {trigger: true});
+        Backbone.history.navigate(route);
         t.strictEqual(router.first, 'has/slash');
         t.strictEqual(router.part, 'has#hash');
         t.strictEqual(router.rest, 'has space');
@@ -444,9 +445,9 @@ function module(moduleName, opts) {
     });
 
     test("#2666 - Hashes with UTF8 in them.", 2, function (t) {
-        Backbone.history.navigate('charñ', {trigger: true});
+        Backbone.history.navigate('charñ');
         t.equal(router.charType, 'UTF');
-        Backbone.history.navigate('char%C3%B1', {trigger: true});
+        Backbone.history.navigate('char%C3%B1');
         t.equal(router.charType, 'UTF');
     });
 


### PR DESCRIPTION
* Changed to `{trigger: true}` by default
* Removed all redundant `{trigger: true}` instances
* Extracted `urlChanged` method to be used within both `navigate` and `checkUrl` methods
* Updated tests (I guess that there's 1 redundant test though which I marked – please verify)
* Updated readme
* All tests pass