### PR TITLE
add phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "browserify": "^4.1.10",
+    "phantomjs": "^1.9.7-15",
     "precommit-hook": "~0.3.10",
     "run-browser": "^1.3.1",
     "tap-spec": "^0.2.0",


### PR DESCRIPTION
Required as a dev dependency so tests will run if it is not installed globally.
