### PR TITLE
Remove duplicate precommit-hook dependency. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,12 @@
     "ampersand-class-extend": "^1.0.0",
     "backbone-events-standalone": "0.2.2",
     "jshint": "^2.5.3",
-    "precommit-hook": "^1.0.7",
     "underscore": "1.6.0"
   },
   "devDependencies": {
     "browserify": "^4.1.10",
     "phantomjs": "^1.9.7-15",
-    "precommit-hook": "~0.3.10",
+    "precommit-hook": "^1.0.7",
     "run-browser": "^1.3.1",
     "tap-spec": "^0.2.0",
     "tape": "^2.13.2",


### PR DESCRIPTION
This commit removes the duplicate `precommit-hook` dependencies and saves it as a dev dependency only. Having this as a production dependency causes the git hook to be written to the project which requires this module.

It looks like #4 fixed the dependency location issue, but it accidentally got re-introduced and then duplicated with [this commit](https://github.com/AmpersandJS/ampersand-router/commit/15833a52fa3e2a0300e74211d657bf7b14c1fb9d).
