### PR TITLE
add history started method and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ var Router = AmpersandRouter.extend({
 
 AmpersandRouter automatically requires and instantiates a single ampersand-history object. AmpersandHistory serves as a global router (per frame) to handle hashchange events or pushState, match the appropriate route, and trigger callbacks. You shouldn't ever have to create one of these yourself since ampersand-router already contains one.
 
-When all of your Routers have been created, and all of the routes are set up properly, call `router.history.start()` on one of your routers to begin monitoring hashchange events, and dispatching routes. Subsequent calls to `history.start()` will throw an error, and `router.history.started` is a boolean value indicating whether it has already been called.
+When all of your Routers have been created, and all of the routes are set up properly, call `router.history.start()` on one of your routers to begin monitoring hashchange events, and dispatching routes. Subsequent calls to `history.start()` will throw an error, and `router.history.started()` is a boolean value indicating whether it has already been called.
 
 Supported options:
 

--- a/ampersand-history.js
+++ b/ampersand-history.js
@@ -123,6 +123,13 @@ extend(History.prototype, Events, {
         if (!this.options.silent) return this.loadUrl();
     },
 
+    // Returns the value of History.started. Allows an app or units tests to
+    // check whether or not the router has been started with
+    // router.history.started(); otherwise the started flag is inaccessible
+    started: function () {
+      return History.started;
+    },
+
     // Disable Backbone.history, perhaps temporarily. Not useful in a real app,
     // but possibly useful for unit testing Routers.
     stop: function () {

--- a/test/index.js
+++ b/test/index.js
@@ -955,4 +955,12 @@ function module(moduleName, opts) {
         Backbone.history.start({pushState: true});
     });
 
+    test("app can know when the history has started", 2, function (t) {
+        Backbone.history.stop();
+        var router = new Backbone.Router({ history: Backbone.history });
+        t.notOk(router.history.started());
+        Backbone.history.start();
+        t.ok(router.history.started());
+    });
+
 })();


### PR DESCRIPTION
The history started flag is inaccessible to the application:
```
var Router = require('ampersand-router');
router = new Router()
console.log(router.history.started);
// undefined
```

This pull request adds a method to the History class that simply returns the started flag. That way the history state can be accessed with `router.history.started()`