### PR TITLE
add section to the example about pairing with ampersand-view-switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ npm install ampersand-router
 <!-- starthide -->
 ## example
 
+In this example the router is trigger a `newPage` event along with the instance of a page. It is up to your application to listen for this event on the router and then do something with the page instance.
+
+This is helpful when paired with the [`ampersand-view-switcher#set`](https://github.com/AmpersandJS/ampersand-view-switcher#set-switchersetviewinstance) method to ensure that the page instance is rendered into the correct container and it gets cleaned up properly via its `remove` method when a new page gets triggered by the router. Check out how the `ampersand` cli accomplishes this within its [router](https://github.com/AmpersandJS/ampersand/blob/41ff011c43e4d3adab06b4b1941583034d58195f/template/shared/client/router.js#L24-L26) and [view-switcher](https://github.com/AmpersandJS/ampersand/blob/41ff011c43e4d3adab06b4b1941583034d58195f/template/shared/client/views/main.js#L53).
+
 ```javascript
 var Router = require('ampersand-router');
 


### PR DESCRIPTION
Closes #39.

As brought up in #39, the example in the readme could use a little more explanation. This attempts to:

- Add some context for how the router's trigger method could be consumed by other core modules
- Link to the example of how this happens in the cli app

This doesn't try to be a full resource for how to build a routed application, but add a little context to the example. I'm open to discussion of whether this is the right line to walk in this case or if this should just point users to a full resource elsewhere.

