### PR TITLE
remove erroneous urlChanged check

### DIFF
--- a/ampersand-history.js
+++ b/ampersand-history.js
@@ -215,7 +215,7 @@ extend(History.prototype, Events, {
             return this.location.assign(url);
         }
 
-        if (options.trigger && this.urlChanged()) return this.loadUrl(fragment);
+        if (options.trigger) return this.loadUrl(fragment);
     },
 
     // Update the hash location, either replacing the current entry, or adding

--- a/test/index.js
+++ b/test/index.js
@@ -293,10 +293,10 @@ function restartHistoryWithoutPushState() {
 
     test("loadUrl is not called for identical routes.", 1, function (t) {
         restartHistoryWithoutPushState();
+        AmpHistory.navigate('route');
         AmpHistory.loadUrl = function () {
             t.ok(false);
         };
-        location.replace('http://example.com#route');
         AmpHistory.navigate('route');
         AmpHistory.navigate('/route');
         AmpHistory.navigate('/route');


### PR DESCRIPTION
Currently ampersand-router does not work because this.fragement is changed and then urlChanged is called, which will subsequently always return false.

Also the test for this appeared to be broken, and passing only because of this bug.