### PR TITLE
Also use pageshow event as URL change cue

### DIFF
--- a/ampersand-history.js
+++ b/ampersand-history.js
@@ -96,6 +96,7 @@ extend(History.prototype, Events, {
         // 'onhashchange' is supported, determine how we check the URL state.
         if (this._hasPushState) {
             addEventListener('popstate', this.checkUrl, false);
+            addEventListener('pageshow', this.checkUrl, false);
         } else if (this._wantsHashChange && this._hasHashChange) {
             addEventListener('hashchange', this.checkUrl, false);
         } else if (this._wantsHashChange) {


### PR DESCRIPTION
In some navigation cases, the `popstate` event is not fired when URL
navigation happens. But, `pageshow` is. So, use that event as an
additional URL change cue.