### PR TITLE
Kill `null` arg sent to all route handlers

### DIFF
--- a/ampersand-router.js
+++ b/ampersand-router.js
@@ -111,12 +111,14 @@ extend(Router.prototype, Events, {
     // extracted decoded parameters. Empty or unmatched parameters will be
     // treated as `null` to normalize cross-browser behavior.
     _extractParameters: function (route, fragment) {
-        var params = route.exec(fragment).slice(1);
-        return params.map(function (param, i) {
-            // Don't decode the search params.
-            if (i === params.length - 1) return param || null;
-            return param ? decodeURIComponent(param) : null;
-        });
+        var enocdedParams = route.exec(fragment).slice(1);
+        var searchParm = enocdedParams.pop();
+        function decodeOrNull(p) {
+          return p ? decodeURIComponent(p) : null;
+        }
+        var params = enocdedParams.map(decodeOrNull);
+        searchParm && params.push(searchParm);
+        return params;
     }
 
 });

--- a/ampersand-router.js
+++ b/ampersand-router.js
@@ -111,12 +111,12 @@ extend(Router.prototype, Events, {
     // extracted decoded parameters. Empty or unmatched parameters will be
     // treated as `null` to normalize cross-browser behavior.
     _extractParameters: function (route, fragment) {
-        var enocdedParams = route.exec(fragment).slice(1);
-        var searchParm = enocdedParams.pop();
+        var encodedParams = route.exec(fragment).slice(1);
+        var searchParm = encodedParams.pop();
         function decodeOrNull(p) {
           return p ? decodeURIComponent(p) : null;
         }
-        var params = enocdedParams.map(decodeOrNull);
+        var params = encodedParams.map(decodeOrNull);
         searchParm && params.push(searchParm);
         return params;
     }

--- a/test/index.js
+++ b/test/index.js
@@ -123,6 +123,7 @@ function restartHistoryWithoutPushState() {
         routes: {
             "noCallback": "noCallback",
             "counter": "counter",
+            "noargs": "noargs",
             "search/:query": "search",
             "search/:query/p:page": "search",
             "charñ": "charUTF",
@@ -200,6 +201,10 @@ function restartHistoryWithoutPushState() {
             this.rest = rest;
         },
 
+        noargs: function() {
+          this.args = arguments;
+        },
+
         query: function (entity, args) {
             this.entity = entity;
             this.queryArgs = args;
@@ -234,7 +239,7 @@ function restartHistoryWithoutPushState() {
         location.replace('http://example.com#search/news');
         AmpHistory.checkUrl();
         t.equal(router.query, 'news');
-        t.equal(router.page, null);
+        t.equal(router.page, undefined);
         t.equal(lastRoute, 'search');
         t.equal(lastArgs[0], 'news');
     });
@@ -244,7 +249,7 @@ function restartHistoryWithoutPushState() {
         location.replace('http://example.com#search/' + encodeURIComponent('тест'));
         AmpHistory.checkUrl();
         t.equal(router.query, 'тест');
-        t.equal(router.page, null);
+        t.equal(router.page, undefined);
         t.equal(lastRoute, 'search');
         t.equal(lastArgs[0], 'тест');
     });
@@ -431,6 +436,13 @@ function restartHistoryWithoutPushState() {
         AmpHistory.checkUrl();
     });
 
+    test("Passes nothing when no arguments are defined", 1, function(t) {
+      restartHistoryWithoutPushState();
+      location.replace('http://example.com#noargs');
+      AmpHistory.checkUrl();
+      t.strictEqual(Object.keys(router.args).length, 0);
+    });
+
     test("#933, #908 - leading slash", 2, function (t) {
         location.replace('http://example.com/root/foo');
 
@@ -470,7 +482,7 @@ function restartHistoryWithoutPushState() {
         location.replace('http://example.com#search/fat');
         AmpHistory.checkUrl();
         t.equal(router.query, 'fat');
-        t.equal(router.page, null);
+        t.equal(router.page, undefined);
         t.equal(lastRoute, 'search');
     });
 
@@ -689,7 +701,7 @@ function restartHistoryWithoutPushState() {
         restartHistoryWithoutPushState();
         router.on('route', function (name, args) {
             t.strictEqual(name, 'routeEvent');
-            t.deepEqual(args, ['x', null]);
+            t.deepEqual(args, ['x']);
         });
         location.replace('http://example.com#route-event/x');
         AmpHistory.checkUrl();


### PR DESCRIPTION
A side-effect of parsing the optional query arg.

Discovered when trying to do something like:

```js
var _ = require('lodash');
var greet = require('./greet');

Router.extend({

  routes: {
    ':name/:greeting': 'greet',
    'hi-doug': 'hiDoug',
    'hi/:name': 'hiPerson',
  },

  greet: greet,
  hiDoug: _.partial(greet, 'doug', 'hi'),
  hiPerson: _.partialRight(greet, 'hi'), // fails via `greet('NameFromUrl', null, 'hi')`
});
```